### PR TITLE
Feature: Add a new command sysinfo

### DIFF
--- a/sysinfo
+++ b/sysinfo
@@ -1,0 +1,4 @@
+for i in baseboard-manufacturer system-version system-product-name chassis-type system-serial-number bios-release-date bios-version
+do
+ echo "$i : $(sudo dmidecode -s $i)"
+done


### PR DESCRIPTION
This command helps to find some info about the system such as serial number. Must be privileged to see it.